### PR TITLE
Various stylesheet improvements

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -34,8 +34,8 @@
                 {% endif %}
             </nav>
         </header>
-        <div class="content">
+        <main>
             {{ content }}
-        </div>
+        </main>
     </body>
 </html>

--- a/blog.css
+++ b/blog.css
@@ -5,7 +5,7 @@ body {
     margin: 0;
 }
 
-.content {
+main {
     max-width: 50em;
     padding: 0 20px 0 20px;
     margin: 0 auto;

--- a/blog.css
+++ b/blog.css
@@ -12,13 +12,12 @@ main {
 }
 
 a {
-    text-decoration: none;
     color: #85beff;
     outline: 0;
 }
 
 a:hover, a:focus {
-    text-decoration: underline;
+    text-decoration: none;
 }
 
 header {
@@ -42,7 +41,14 @@ nav a {
     font-size: 20px;
 }
 
-header a { color: white; }
+header a {
+    color: white;
+    text-decoration: none;
+}
+
+header a:hover, header a:focus {
+    text-decoration: underline;
+}
 
 .title {
     display: flex;
@@ -105,12 +111,12 @@ aside span { font-weight: bold }
 
 .aside-update     { border-left: 4px solid green }
 .aside-warning    { border-left: 4px solid orange }
-.aside-disclaimer { border-left: 4px solid #eb152e }
+.aside-disclaimer { border-left: 4px solid #ff354c }
 .aside-fun-fact   { border-left: 4px solid #34a8eb }
 
 .aside-update span     { color: #32a852 }
 .aside-warning span    { color: orange }
-.aside-disclaimer span { color: #eb152e }
+.aside-disclaimer span { color: #ff354c }
 .aside-fun-fact span   { color: #34a8eb }
 
 hr {
@@ -132,6 +138,18 @@ hr {
     }
 
     aside {
-        background-color: #e5e5e5;
+        background-color: #fff;
     }
+
+    .desc {
+        color: #505050;
+    }
+
+    .aside-update     { border-left: 4px solid green }
+    .aside-disclaimer { border-left: 4px solid #de2e42 }
+    .aside-fun-fact   { border-left: 4px solid #267cad }
+
+    .aside-update span     { color: green }
+    .aside-disclaimer span { color: #de2e42 }
+    .aside-fun-fact span   { color: #267cad }
 }

--- a/index.html
+++ b/index.html
@@ -14,16 +14,16 @@ layout: default
         <img src="/assets/icon.png" alt="{{ site.title }} icon" class="icon hhidden" />
         <div class="title">
             <h1>{{ site.title }}</h1>
-            <h2>The Linux shell for iOS.</h2>
+            <p class="slogan">The Linux shell for iOS.</p>
             <div class="actions">
                 <a class="get" href="{{ site.links.appstore }}">
-                    <img src="/assets/appstore.svg" alt="Apple App Store icon" />
+                    <img src="/assets/appstore.svg" alt="" />
                     <p>Get on the App Store</p>
                 </a>
             </div>
             <div class="actions">
                 <a class="get" href="/altstore">
-                    <img src="/assets/altstore.png" alt="AltStore icon" />
+                    <img src="/assets/altstore.png" alt="" />
                     <p>Get {{ site.title }} on AltStore</p>
                 </a>
             </div>
@@ -39,13 +39,13 @@ layout: default
 </section>
 
 <section id="info" class="alt-section">
-    <h1><strong>Wait, what's {{ site.title }}?</strong></h1>
+    <h2><strong>Wait, what's {{ site.title }}?</strong></h2>
     <p>
         {{ site.title }} is a project to get a Linux shell environment running locally on your iOS device, using a usermode x86 emulator.
     </p>
     <div class="tidbits">
         <div class="tidbit large">
-            <h2>iPadOS? You bet.</h2>
+            <h3>iPadOS? You bet.</h3>
             <p>{{ site.title }} also runs on iPad, bringing a terminal to larger displays as well.</p>
             <div class="growth"></div>
             <picture>
@@ -58,7 +58,7 @@ layout: default
             <div class="growth"></div>
         </div>
         <div class="tidbit">
-            <h2>BusyBox</h2>
+            <h3>BusyBox</h3>
             <p>You can edit files with sed and cat, move them around, and more!</p>
             <picture>
                 <source type="image/webp" media="(prefers-color-scheme: dark)" srcset="/assets/iphone-busybox-dark.webp">
@@ -69,7 +69,7 @@ layout: default
             </picture>
         </div>
         <div class="tidbit">
-            <h2>Keyboard CTRL</h2>
+            <h3>Keyboard CTRL</h3>
             <p>{{ site.title }}'s keyboard addition makes navigation easier.</p>
             <picture>
                 <source type="image/webp" srcset="/assets/iphone-keyboard.webp">
@@ -81,13 +81,13 @@ layout: default
 </section>
 
 <section id="get">
-    <h1><strong>Sounds cool, can I get that?</strong></h1>
+    <h2><strong>Sounds cool, can I get that?</strong></h2>
     <p>Of course, let's get started!</p>
     <div class="getcontainer">
         <div>
             <div class="actions">
                 <a class="get" href="{{ site.links.appstore }}">
-                    <img src="/assets/appstore.svg" alt="Apple App Store icon" />
+                    <img src="/assets/appstore.svg" alt="" />
                     <p>Get on the App Store</p>
                 </a>
             </div>
@@ -99,7 +99,7 @@ layout: default
         <div>
             <div class="actions">
                 <a class="get" href="/altstore">
-                    <img src="/assets/altstore.png" alt="AltStore icon" />
+                    <img src="/assets/altstore.png" alt="" />
                     <p>Get {{ site.title }} on AltStore</p>
                 </a>
             </div>

--- a/style.css
+++ b/style.css
@@ -34,21 +34,22 @@ hr {
 }
 
 header {
-    height: 60px;
-    width: 100%;
-    line-height: 32px;
+    width: 100vw;
+}
+
+nav {
+    padding: 12px;
     display: flex;
     align-items: center;
     justify-content: center;
+    gap: 12px;
 }
 
-nav { display: inherit; }
-
 nav a {
+    flex-grow: 1;
     background-color: rgba(255, 255, 255, 0.1);
-    padding: 0 8px 0 8px;
-    width: 140px;
-    margin: 0 12px 0 12px;
+    max-width: 140px;
+    line-height: 32px;
     border-radius: 8px;
     transition: background .05s ease-in-out, border-color .2s;
     border: 2px solid rgba(255, 255, 255, 0.1);
@@ -81,7 +82,7 @@ footer p {
     justify-content: space-between;
     align-items: center;
     background: linear-gradient(180deg, var(--ish-primary), var(--ish-secondary));
-    height: 100vh;
+    min-height: 100vh;
 }
 
 /* Contains entire front page */
@@ -296,12 +297,6 @@ section > p {
 
 /* Mobile optimisations */
 @media only screen and (max-width: 750px) {
-    header { justify-content: space-around; }
-    nav a {
-        padding: 0 5px 0 5px;
-        width: 80px;
-        margin: 6px;
-    }
     .front-container {
         flex-direction: column;
         margin: 0;
@@ -335,15 +330,6 @@ section > p {
 
 @media only screen and (max-width: 860px) {
     .iphone { display: none; }
-}
-
-@media only screen and (max-width: 400px) {
-    nav a {
-        padding: 2px 8px 2px 8px;
-        width: auto;
-        margin: 4px;
-        font-size: 13.5pt;
-    }
 }
 
 /* AltStore page */

--- a/style.css
+++ b/style.css
@@ -17,15 +17,14 @@ body {
     font-size: 13pt;
 }
 
-h1, h2 { font-weight: 400; }
+h1, h2, h3 { font-weight: 400; }
 
 a {
     color: var(--ish-blue);
-    text-decoration: none;
     outline: 0;
 }
 
-a:hover, a:focus { text-decoration: underline; }
+a:hover, a:focus { text-decoration: none; }
 
 hr {
     border: 0;
@@ -54,6 +53,7 @@ nav a {
     transition: background .05s ease-in-out, border-color .2s;
     border: 2px solid rgba(255, 255, 255, 0.1);
     color: white;
+    text-decoration: none;
 }
 
 nav a:hover, nav a:focus {
@@ -122,6 +122,8 @@ footer p {
     transition: border-color .15s ease-in-out;
     padding: 0.4em;
     margin-bottom: 6px;
+    text-decoration: none;
+    color: #fff;
 }
 
 .get img {
@@ -135,7 +137,6 @@ footer p {
     flex-grow: 1;
     font-size: 15pt;
     margin: 0;
-    color: #fff;
 }
 
 .get:hover, .get:focus {
@@ -154,7 +155,9 @@ footer p {
     line-height: 48px;
 }
 
-.title h1, .title h2 { margin: 10px 0 10px 0; }
+.title .slogan { font-size: 19pt }
+
+.title h1, .title .slogan { margin: 10px 0 10px 0; }
 
 .iphone {
     height: auto;
@@ -168,7 +171,7 @@ footer p {
     padding: 1px;
 }
 
-section > h1 {
+section > h2 {
     font-size: 22pt;
     margin: 20px 0 0 0;
 }
@@ -206,9 +209,10 @@ section > p {
 }
 
 .tidbit p { margin: 4px 0 12px 0; }
-.tidbit h2 {
-    margin: 4px 0 0 0;
+.tidbit h3 {
+    margin: 4px 0;
     color: var(--ish-purple);
+    font-size: 19pt;
 }
 
 .tidbit img {
@@ -377,6 +381,12 @@ section > p {
     }
     body, .alt-section, #altstore-container { color: #000; }
     #home { color: #fff; }
+    .getcontainer .get {
+        background-color: var(--background-alt);
+        color: black;
+    }
+    .getcontainer .get { border: 2px solid var(--accent); }
+    .getcontainer .get:hover, .getcontainer .get:focus { border: 2px solid var(--ish-blue); }
     .tidbit {
         border: 2px solid var(--accent);
         background-color: var(--background);


### PR DESCRIPTION
Resolved:
- Links relying on colour to be distinguished
- Contrast minimums not being met
- Index having wrong hX-semantics
- Focus styles not showing correctly on "Get" links
- "Get" links having unimportant image alt texts (making accessible link names worse)
- Content could run off the hero banner and smash into sections below if the window was too small

Improved:
- Header links no longer snap to different `@media`-sizes and instead just flex