### PR TITLE
fix: version should match app's release version

### DIFF
--- a/altstore.json
+++ b/altstore.json
@@ -2,6 +2,9 @@
 ---
 {%- assign release = site.github.releases | first -%}
 {%- assign asset = release.assets | where: "name", "iSH.ipa" -%}
+{%- assign version_parts = release.name | split: "-build" -%}
+{%- assign release_version = version_parts[0] -%}
+{%- assign build_number = version_parts[1] -%}
 {
     "name": {{ site.title | jsonify }},
     "identifier": "app.ish.iSH",
@@ -17,7 +20,8 @@
             "screenshotURLs": [
                 {{ "/assets/front-iphone-full.png" | absolute_url | jsonify }}
             ],
-            "version": {{ release.name | jsonify }},
+            "version": {{ release_version | jsonify }},
+            "buildNumber": {{ build_number | jsonify }},
             "versionDate": {{ release.created_at | date_to_xmlschema | jsonify }},
             "versionDescription": {{ release.body | jsonify }},
             "downloadURL": {{ asset[0].browser_download_url | jsonify }},


### PR DESCRIPTION
This is another attempt of addressing the issue that #46 tried to resolve.

# Problem

Currently, the ish.app AltStore source is incompatible with AltStore 2.0 and SideStore (https://github.com/ish-app/ish/issues/2563). The previous attempt of trying to solve this on the ish.app project (https://github.com/ish-app/ish.app/pull/46) was hardcoding the version number, which was an area of feedback that couldn't be addressed, since a given GitHub release provides no indication of the app version that the build is for.

# Solution

I've opened a PR on the ish project (https://github.com/ish-app/ish/pull/2658) that will name each nightly GitHub release in semver formatting: `<version number>-build<build number>`. 

With that change, we can then parse this information in the JSON template here to properly provide both the app version and build number to the appropriate AltStore Source fields. I've opened a PR for that change on the ish.app repo: 
